### PR TITLE
[WIP] Handling patch automatically

### DIFF
--- a/Tutorials/Blogging/Blogging.ServiceModel.NetCore/Article.cs
+++ b/Tutorials/Blogging/Blogging.ServiceModel.NetCore/Article.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 
 namespace Blogging.ServiceModel
 {
@@ -15,5 +16,8 @@ namespace Blogging.ServiceModel
         public long ArticleId { get; set; }
         public string Title { get; set; }
         public string Text { get; set; }
+        public int TimesOpened { get; set; }
+        public DateTime PublishedDate { get; set; }
+        public float AverageScore { get; set; }
     }
 }

--- a/Tutorials/Blogging/Blogging.WebService.NetCore/BloggingRepository.cs
+++ b/Tutorials/Blogging/Blogging.WebService.NetCore/BloggingRepository.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 using Blogging.ServiceModel;
@@ -58,6 +58,16 @@ namespace Blogging.WebService
 
             article.ArticleId = this.NextArticleId++;
             dataContext.ArticleTable.Add(article);
+            dataContext.SaveChanges();
+
+            return article;
+        }
+
+        public Article UpdateArticle(Article article)
+        {
+            using var dataContext = this.CreateDataContext();
+
+            dataContext.ArticleTable.Update(article);
             dataContext.SaveChanges();
 
             return article;

--- a/Tutorials/Blogging/Blogging.WebService.NetCore/Controllers/ArticlesController.cs
+++ b/Tutorials/Blogging/Blogging.WebService.NetCore/Controllers/ArticlesController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 
 using Blogging.ServiceModel;
@@ -313,7 +313,10 @@ namespace Blogging.WebService.Controllers
         [HttpPatch("articles/{id}")]
         public IActionResult Patch(string id, [FromBody]Document inDocument)
         {
-            throw new NotImplementedException();
+            var updatedArticle = this.CreateUpdatedArticle(id, inDocument);
+            var (document, link) = this.CreateDocumentAndLink(updatedArticle);
+
+            return this.Ok(document);
         }
 
         [HttpDelete("articles/{id}")]
@@ -361,6 +364,21 @@ namespace Blogging.WebService.Controllers
             validator.ValidateAndThrow(inArticle);
 
             var outArticle = this.BloggingRepository.CreateArticle(inArticle);
+            return outArticle;
+        }
+
+        private Article CreateUpdatedArticle(string id, Document inDocument)
+        {
+            using var documentContext = this.ApiServiceContext.CreateApiDocumentContext(inDocument);
+
+            var articleToBeUpdated = this.BloggingRepository.GetArticle(Convert.ToInt64(id));
+
+            documentContext.UpdateResource<Article>(inDocument, articleToBeUpdated);
+
+            var validator = new ArticleValidator();
+            validator.ValidateAndThrow(articleToBeUpdated);
+
+            var outArticle = this.BloggingRepository.UpdateArticle(articleToBeUpdated);
             return outArticle;
         }
 

--- a/Tutorials/Blogging/Blogging.WebService.NetCore/JsonApiFrameworkExtensions.cs
+++ b/Tutorials/Blogging/Blogging.WebService.NetCore/JsonApiFrameworkExtensions.cs
@@ -1,0 +1,101 @@
+using JsonApiFramework.JsonApi;
+using JsonApiFramework.Server;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Linq;
+
+namespace Blogging.WebService
+{
+    public static class JsonApiFrameworkExtensions
+    {
+        /// <summary>
+        /// Update the resource informed in a PATCH request.
+        /// <para>This method only updates the properties of <paramref name="resourceToBeUpdated"/> that are included in <paramref name="document"/></para>
+        /// </summary>
+        /// <typeparam name="TResource"></typeparam>
+        /// <param name="ctx">Document context</param>
+        /// <param name="document">Document containing the changes sent in the PATCH request</param>
+        /// <param name="resourceToBeUpdated">Resource which values will be updated by the fields informed in the <paramref name="document"/> </param>
+        public static void UpdateResource<TResource>(this DocumentContext ctx, Document document, TResource resourceToBeUpdated)
+        {
+            Type clrResourceType = typeof(TResource);
+            var serviceModelOfType = ctx.ServiceModel.ResourceTypes.FirstOrDefault(res => res.ClrType.FullName.Equals(clrResourceType.FullName));
+            var serviceModelTypeAttributeInfo = serviceModelOfType.AttributesInfo;
+            Resource sentResource = document.GetData() as Resource;
+
+            ApiObject inDocumentSentAttributes = sentResource.Attributes ?? new ApiObject();
+            foreach (ApiReadProperty sentAttribute in inDocumentSentAttributes)
+            {
+                var clrPropertyName = serviceModelTypeAttributeInfo
+                    .Collection
+                    .Where(at => at.ApiPropertyName.Equals(sentAttribute.Name))
+                    .Select(at => at.ClrPropertyName)
+                    .First();
+
+                JValue jValue = sentAttribute.Value as JValue;
+                object rawValue = JTokenToConventionalDotNetObject(jValue);
+                clrResourceType
+                    .GetProperty(clrPropertyName)
+                    .SetValue(resourceToBeUpdated, rawValue);
+            }
+
+            Relationships inDocumentSentRelationships = sentResource.Relationships ?? new Relationships();
+            var serviceModelTypeRelationshipsInfo = serviceModelOfType.RelationshipsInfo;
+            foreach (var sentRelationship in inDocumentSentRelationships)
+            {
+                var key = sentRelationship.Key;
+                var value = sentRelationship.Value;
+
+                var type = serviceModelTypeRelationshipsInfo
+                            .Collection
+                            .Where(rel => rel.Rel.Equals(key))
+                            .Select(at => at.ToClrType)
+                            .First();
+
+                // If I were able to get the property name of the relationship (something the same way I got the attribute names), I would be able to update the value dynamically.
+                // These property names can be stored in the Service Model (in the ToOneRelationship/ToManyRelationship object), or probably with the EF Core itself.
+                if (value is ToOneRelationship toOneRel)
+                {
+                    throw new ArgumentException("Updating to one relationships is not supported");
+                }
+                else if (value is ToManyRelationship)
+                {
+                    throw new ArgumentException("Updating to-many relationships is not supported");
+                    // Can probably be done by instantiating a list of the type with the sent Ids 
+                }
+            }
+        }
+
+        /// <summary>Converts a Json.Net JToken to a boxed conventional .NET type (int, List, etc.)</summary>
+        /// <param name="token">The JToken to evaluate</param>
+        /// <remarks>
+        /// Credits to the original implementation of this method: <a href="https://stackoverflow.com/a/36659561/9990676">Convert Json.NET objects to conventional .NET objects without knowing the types [duplicate]</a>
+        /// </remarks>
+        private static object JTokenToConventionalDotNetObject(JToken token)
+        {
+            // TODO This method needs improvement: Number precision are being lost with the actual implementation:
+            //  - When the type is JTokenType.Integer, the returned value is always int64. 
+            //  - If the value is JTokenType.Float, the same rule applies, the value is aways Double.
+            // The numbers need to be casted down if needed to avoid type errors in the clients of this method.
+
+            switch (token.Type)
+            {
+                case JTokenType.Object:
+                    return ((JObject)token).Properties()
+                        .ToDictionary(prop => prop.Name, prop => JTokenToConventionalDotNetObject(prop.Value));
+                case JTokenType.Array:
+                    return token.Values().Select(JTokenToConventionalDotNetObject).ToList();
+                case JTokenType.Integer:
+                    long rawIntValue = token.ToObject<long>();
+                    if (rawIntValue >= -32768 && rawIntValue <= 32767) return Convert.ToInt16(rawIntValue);
+                    if (rawIntValue >= -2147483648 && rawIntValue <= 2147483647) return Convert.ToInt32(rawIntValue);
+                    return rawIntValue;
+                case JTokenType.Float:
+                    double rawDoubleValue = token.ToObject<double>();
+                    return Convert.ToSingle(rawDoubleValue);
+                default:
+                    return token.ToObject<object>();
+            }
+        }
+    }
+}


### PR DESCRIPTION
In response to  [#76](https://github.com/scott-mcdonald/JsonApiFramework/issues/76)
This is a implementation to handle a PATCH request automatically.  
This library is very powerful but having to handle a PATCH request by manually updating every field looks bad.  

This PR introduces the `UpdateResource` method to  `DocumentContext` as an extension method.   
Method signature: 


```c#

UpdateResource<TResource>(this DocumentContext ctx, Document document, TResource resourceToBeUpdated)

```

### Which fields can be updated 

#### Supported attributes 
- [x] `DateTime`
- [x] `string`
- [x] `int`
- [x] `float`
- [ ] `double` (loses precision)
- [ ] ... assume others not supported

#### Supported Relationships
- [ ] to-one relationships
- [ ] to- many relationships

P.S:
This is just a naive implementation. Feel free to criticize and suggest alternatives.  